### PR TITLE
seed_cbc undefined 변수 수정

### DIFF
--- a/plugin/inicert/libs/KISA_SEED_CBC.php
+++ b/plugin/inicert/libs/KISA_SEED_CBC.php
@@ -782,6 +782,7 @@ class KISA_SEED_CBC {
         $pbszCipherText = array_pad(array(), $message_length, 0);
         Common::arraycopy_system($message, $message_offset, $pbszCipherText, 0, $message_length);
         $nCipherTextLen = count($pbszCipherText);
+        $result = null;
 
         if ($nCipherTextLen % KISA_SEED_CBC::BLOCK_SIZE_SEED) {
             return $result;


### PR DESCRIPTION
SEED_CBC_Decrypt 함수
return $result 전에 초기화

kisa 에서 제공하는
https://seed.kisa.or.kr/kisa/Board/17/detailView.do

PHP CBC 파일의 SEED_CBC_Decrypt 에는 $result 변수 초기화가 있습니다.